### PR TITLE
PR for #51: Fix issue with lfs files in child repos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,1 @@
-*.csv filter=lfs diff=lfs merge=lfs -text
-*.dta filter=lfs diff=lfs merge=lfs -text
-*.rda filter=lfs diff=lfs merge=lfs -text
-*.rds filter=lfs diff=lfs merge=lfs -text
-*.pdf filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.zip filter=lfs diff=lfs merge=lfs -text
-*.tar.gz filter=lfs diff=lfs merge=lfs -text
 *.log merge=binary

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ These software are used by the scripts contained in the repository. By default, 
 
    If you wish to not specify any external paths and/or to use the default executable names, you can skip this step and the default `config_user.yaml` will be copied over in step 4.
 
-2. Optionally run the script `/setup/lfs_setup.sh`. This will instruct `git lfs` to handle files with extensions such as `.pdf`, `.png`, etc. This will not affect files that ship with the template. See [here](https://git-lfs.github.com/) for more information about modifying your repository's `git lfs` settings. 
-
-3. If you already have conda setup on your local machine, feel free to skip this step. If not, this will install a lightweight version of `conda` that will not interfere with your current `python` and `R` installations.
+2. If you already have conda setup on your local machine, feel free to skip this step. If not, this will install a lightweight version of `conda` that will not interfere with your current `python` and `R` installations.
 
    Install `miniconda` and `jdk` to be used to manage the R/Python virtual environment, if you have not already done this. You can install these programs from their websites [here for miniconda](https://docs.conda.io/en/latest/miniconda.html) and [here for jdk](https://www.oracle.com/java/technologies/javase-downloads.html). If you use homebrew (which can be download [here](https://brew.sh/)) these two programs can be downloaded as follows:
       ```
@@ -34,7 +32,7 @@ These software are used by the scripts contained in the repository. By default, 
       conda init $(echo $0 | cut -d'-' -f 2)
       ```
 
-4. Create conda environment with the command:
+3. Create conda environment with the command:
       ```
       conda env create -f setup/conda_env.yaml
       ```
@@ -47,14 +45,21 @@ These software are used by the scripts contained in the repository. By default, 
       conda deactivate
       ```
 
-5. Fetch `gslab_make` submodule files. We use a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to track our `gslab_make` dependency in the `/lib/gslab_make` folder. After cloning the repository, you will need to initialize and fetch files for the `gslab_make` submodule. One way to do this is to run the following bash commands from the root of the repository:
+4. Fetch `gslab_make` submodule files. We use a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to track our `gslab_make` dependency in the `/lib/gslab_make` folder. After cloning the repository, you will need to initialize and fetch files for the `gslab_make` submodule. One way to do this is to run the following bash commands from the root of the repository:
    ```
    git submodule init
    git submodule update
    ``` 
    Once these commands have run to completion, the `/lib/gslab_make` folder should be populated with `gslab_make` files.   
 
-6. Run the `/setup/check_setup.py` file. One way to do this is to run the following bash command in a terminal from the `/setup` subdirectory:
+5. Optionally run the script to start `git lfs`. From the root of the repository, run:
+   ```
+   ./setup/lfs_setup.sh
+   ```
+
+   This will instruct `git lfs` to handle files with extensions such as `.pdf`, `.png`, etc. This will not affect files that ship with the template. See [here](https://git-lfs.github.com/) for more information about modifying your repository's `git lfs` settings. 
+
+6. Run the script `/setup/check_setup.py`. One way to do this is to run the following bash command from the `/setup` directory:
    ```
    python3 check_setup.py
    ```

--- a/README.md
+++ b/README.md
@@ -15,22 +15,26 @@ These software are used by the scripts contained in the repository. By default, 
 
 ## Setup 
 
-1. Create a `config_user.yaml` file in the root directory. A template can be found in the `setup` subdirectory. See the **User Configuration** section below for further detail. If you do not have any external paths you wish to specify, and wish to use the default executable names you can skip this step and the default `config_user.yaml` will be copied over in step 4.
+1. Create a `config_user.yaml` file in the root directory. A template can be found in the `/setup` directory. See the **User Configuration** section below for further detail. 
 
-2. If you already have conda setup on your local machine, feel free to skip this step. If not, this will install a lightweight version of conda that will not interfere with your current python and R installations.
+   If you wish to not specify any external paths and/or to use the default executable names, you can skip this step and the default `config_user.yaml` will be copied over in step 4.
 
-   Install miniconda and jdk to be used to manage the R/Python virtual environment, if you have not already done this. You can install these programs from their websites [here for miniconda](https://docs.conda.io/en/latest/miniconda.html) and [here for jdk](https://www.oracle.com/java/technologies/javase-downloads.html). If you use homebrew (which can be download [here](https://brew.sh/)) these two programs can be downloaded as follows:
+2. Optionally run the script `/setup/lfs_setup.sh`. This will instruct `git lfs` to handle files with extensions such as `.pdf`, `.png`, etc. This will not affect files that ship with the template. See [here](https://git-lfs.github.com/) for more information about modifying your repository's `git lfs` settings. 
+
+3. If you already have conda setup on your local machine, feel free to skip this step. If not, this will install a lightweight version of `conda` that will not interfere with your current `python` and `R` installations.
+
+   Install `miniconda` and `jdk` to be used to manage the R/Python virtual environment, if you have not already done this. You can install these programs from their websites [here for miniconda](https://docs.conda.io/en/latest/miniconda.html) and [here for jdk](https://www.oracle.com/java/technologies/javase-downloads.html). If you use homebrew (which can be download [here](https://brew.sh/)) these two programs can be downloaded as follows:
       ```
       brew install --cask miniconda
       brew install --cask oracle-jdk
       ```
-   Once you have done this you need to initialize conda by running the following lines and restarting your terminal:
+   Once you have done this you need to initialize `conda` by running the following lines and restarting your terminal:
       ```
       conda config --set auto_activate_base false
       conda init $(echo $0 | cut -d'-' -f 2)
       ```
 
-3. Create conda environment with the command:
+4. Create conda environment with the command:
       ```
       conda env create -f setup/conda_env.yaml
       ```
@@ -38,19 +42,19 @@ These software are used by the scripts contained in the repository. By default, 
       ```
       conda activate PROJECT_NAME
       ```
-   The environment should be active throughout setup, and whenver executing modules within the project in the future. If you wish to return to your base environment, you can deactivate the conda environment with
+   The environment should be active throughout setup, and whenver executing modules within the project in the future. You can deactivate the `conda` environment with
       ```
       conda deactivate
       ```
 
-4. Fetch `gslab_make` submodule files. We use a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to track our `gslab_make` dependency in the `/lib/gslab_make` folder. After cloning the repository, you will need to initialize and fetch files for the `gslab_make` submodule. One way to do this is to run the following bash commands from the root of the repository:
+5. Fetch `gslab_make` submodule files. We use a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to track our `gslab_make` dependency in the `/lib/gslab_make` folder. After cloning the repository, you will need to initialize and fetch files for the `gslab_make` submodule. One way to do this is to run the following bash commands from the root of the repository:
    ```
    git submodule init
    git submodule update
    ``` 
    Once these commands have run to completion, the `/lib/gslab_make` folder should be populated with `gslab_make` files.   
 
-5. Run the `/setup/check_setup.py` file. One way to do this is to run the following bash command in a terminal from the `setup` subdirectory:
+6. Run the `/setup/check_setup.py` file. One way to do this is to run the following bash command in a terminal from the `/setup` subdirectory:
    ```
    python3 check_setup.py
    ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These software are used by the scripts contained in the repository. By default, 
 
 1. Create a `config_user.yaml` file in the root directory. A template can be found in the `/setup` directory. See the **User Configuration** section below for further detail. 
 
-   If you wish to not specify any external paths and/or to use the default executable names, you can skip this step and the default `config_user.yaml` will be copied over in step 4.
+   If this step is skipped, the default `config_user.yaml` will be copied over in step 4. You might skip this step if you wish not to specify any external paths, or if you wish to use the default executable names. 
 
 2. If you already have conda setup on your local machine, feel free to skip this step. If not, this will install a lightweight version of `conda` that will not interfere with your current `python` and `R` installations.
 
@@ -40,7 +40,7 @@ These software are used by the scripts contained in the repository. By default, 
       ```
       conda activate PROJECT_NAME
       ```
-   The environment should be active throughout setup, and whenver executing modules within the project in the future. You can deactivate the `conda` environment with
+   The environment should be active throughout setup, and whenever executing modules within the project in the future. You can deactivate the `conda` environment with
       ```
       conda deactivate
       ```

--- a/setup/lfs_setup.sh
+++ b/setup/lfs_setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+git lfs track "*.csv"
+git lfs track "*.dta"
+git lfs track "*.rda"
+git lfs track "*.rds"
+git lfs track "*.pdf"
+git lfs track "*.png"
+git lfs track "*.zip"
+git lfs track "*.tar.gz"
+git lfs track "*.csv"
+
+git add .gitattributes


### PR DESCRIPTION
Closes #51. 

This PR includes code that should eliminate issues with `git lfs` when creating child repos from `gentzkow/template`. A script has been added to `/setup` to initialize `git lfs` tracking as before. The `README` has been updated. 