### PR TITLE
PR for #53: Review dependencies

### DIFF
--- a/setup/conda_env.yaml
+++ b/setup/conda_env.yaml
@@ -10,14 +10,9 @@ dependencies:
   - termcolor
   - colorama
   - jupyter
-  - future
   - linearmodels
-  - pip=19
-  - r=3.6
-  - r-yaml # import r packages by prepending with "r-""
-  - r-tidyverse
-  - r-r.utils
-  - r-plm
-  - r-janitor
+  # - pip=19
   # - pip: # if there is a package available via pip but not with conda, can import like this:
   #     - EXAMPLE_PACKAGE
+  # - r=3.6
+  # - r-yaml # import r packages by prepending with "r-""


### PR DESCRIPTION
Closes #53.

This issue eliminates dependencies from the conda environment in order to simplify the initial conda environment build.