### PR TITLE
#73 Fix error in check_setup when freezing dependencies

### DIFF
--- a/setup/check_setup.py
+++ b/setup/check_setup.py
@@ -39,12 +39,14 @@ def get_python(packages):
     prefixes_python = ('python', 'python=', "pip=", "r=", "r-", "r", "pyyaml", "gitpython")
     python_packages = [item for item in packages['dependencies'] if not 
                        item.startswith(prefixes_python)]
+    python_packages = [p.split("=")[0] for p in python_packages]
     return python_packages
 
 
 def get_r(packages):
     prefixes_r = ("r-")
     r_packages = [item for item in packages['dependencies'] if item.startswith(prefixes_r)] 
+    r_packages = [p.split("=")[0] for p in r_packages]
     return r_packages
 
 
@@ -122,6 +124,7 @@ def check_dependencies():
         os._exit(0)    
     # List all R packages which need to be installed.
     for package in r_packages:
+        package = package.replace('r-r.',"")
         package = package.replace('r-',"")
         output = str(subprocess.run(['Rscript', '-e', f'library("{package}")']))
         if "returncode=0" not in output:

--- a/setup/conda_env.yaml
+++ b/setup/conda_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - matplotlib
   - gitpython
-  - termcolor
+  - termcolor = 2.0.9
   - colorama
   - jupyter
   - linearmodels


### PR DESCRIPTION
This PR closes #73. The goal of this issue was to address a bug flagged by @zkashner on `check_setup.py`. Per https://github.com/gentzkow/template/issues/73#issuecomment-1382937861, we currently want `check_setup.py` to (i) allow fixing packages to a specific version and (ii) checking that all required packages have been installed (independent of their version). 

The steps to check the current solution is working as expected are the following:
- Clone template and specify a version for any of the packages listed in `conda_env.yaml`
- Create the `template` conda environment and run `check_setup.py`. Confirm this script runs without any errors. 

@snairdesai let me know if you have the bandwidth to briefly review this PR.